### PR TITLE
Allow users to specify filters by dragging items/fluids from JEI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build
 # other
 eclipse
 run
+logs
 
 # Files from Forge MDK
 forge*changelog.txt

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     runtimeOnly fg.deobf("curse.maven:mekanism:3134211")
 
     // compile against the JEI API but do not include it at runtime
-//    compileOnly fg.deobf("mezz.jei:jei-1.15.2:6.0.0.2:api")
+    compileOnly fg.deobf("mezz.jei:jei-1.16.4:7.6.1.68:api")
     // at runtime, use the full JEI jar
-//    runtimeOnly fg.deobf("mezz.jei:jei-1.15.2:6.0.0.2")
+    runtimeOnly fg.deobf("mezz.jei:jei-1.16.4:7.6.1.68")
 }

--- a/src/main/java/com/supermartijn642/trashcans/TrashCans.java
+++ b/src/main/java/com/supermartijn642/trashcans/TrashCans.java
@@ -4,6 +4,8 @@ import com.supermartijn642.trashcans.compat.Compatibility;
 import com.supermartijn642.trashcans.filter.FluidFilterManager;
 import com.supermartijn642.trashcans.filter.LiquidTrashCanFilters;
 import com.supermartijn642.trashcans.packet.PacketChangeEnergyLimit;
+import com.supermartijn642.trashcans.packet.PacketChangeItemFilter;
+import com.supermartijn642.trashcans.packet.PacketChangeLiquidFilter;
 import com.supermartijn642.trashcans.packet.PacketToggleEnergyLimit;
 import com.supermartijn642.trashcans.packet.PacketToggleItemWhitelist;
 import com.supermartijn642.trashcans.packet.PacketToggleLiquidWhitelist;
@@ -33,36 +35,37 @@ import net.minecraftforge.registries.ObjectHolder;
 /**
  * Created 7/7/2020 by SuperMartijn642
  */
-@Mod("trashcans")
+@Mod(TrashCans.MODID)
 public class TrashCans {
 
-    public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(new ResourceLocation("trashcans", "main"), () -> "1", "1"::equals, "1"::equals);
+    public static final String MODID = "trashcans";
+    public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(new ResourceLocation(MODID, "main"), () -> "2", "2"::equals, "2"::equals);
 
-    @ObjectHolder("trashcans:item_trash_can")
+    @ObjectHolder("item_trash_can")
     public static Block item_trash_can;
-    @ObjectHolder("trashcans:liquid_trash_can")
+    @ObjectHolder("liquid_trash_can")
     public static Block liquid_trash_can;
-    @ObjectHolder("trashcans:energy_trash_can")
+    @ObjectHolder("energy_trash_can")
     public static Block energy_trash_can;
-    @ObjectHolder("trashcans:ultimate_trash_can")
+    @ObjectHolder("ultimate_trash_can")
     public static Block ultimate_trash_can;
 
-    @ObjectHolder("trashcans:item_trash_can_tile")
+    @ObjectHolder("item_trash_can_tile")
     public static TileEntityType<TrashCanTile> item_trash_can_tile;
-    @ObjectHolder("trashcans:liquid_trash_can_tile")
+    @ObjectHolder("liquid_trash_can_tile")
     public static TileEntityType<TrashCanTile> liquid_trash_can_tile;
-    @ObjectHolder("trashcans:energy_trash_can_tile")
+    @ObjectHolder("energy_trash_can_tile")
     public static TileEntityType<TrashCanTile> energy_trash_can_tile;
-    @ObjectHolder("trashcans:ultimate_trash_can_tile")
+    @ObjectHolder("ultimate_trash_can_tile")
     public static TileEntityType<TrashCanTile> ultimate_trash_can_tile;
 
-    @ObjectHolder("trashcans:item_trash_can_container")
+    @ObjectHolder("item_trash_can_container")
     public static ContainerType<ItemTrashCanContainer> item_trash_can_container;
-    @ObjectHolder("trashcans:liquid_trash_can_container")
+    @ObjectHolder("liquid_trash_can_container")
     public static ContainerType<LiquidTrashCanContainer> liquid_trash_can_container;
-    @ObjectHolder("trashcans:energy_trash_can_container")
+    @ObjectHolder("energy_trash_can_container")
     public static ContainerType<EnergyTrashCanContainer> energy_trash_can_container;
-    @ObjectHolder("trashcans:ultimate_trash_can_container")
+    @ObjectHolder("ultimate_trash_can_container")
     public static ContainerType<UltimateTrashCanContainer> ultimate_trash_can_container;
 
     public TrashCans(){
@@ -72,6 +75,8 @@ public class TrashCans {
         CHANNEL.registerMessage(1, PacketToggleLiquidWhitelist.class, PacketToggleLiquidWhitelist::encode, PacketToggleLiquidWhitelist::decode, PacketToggleLiquidWhitelist::handle);
         CHANNEL.registerMessage(2, PacketToggleEnergyLimit.class, PacketToggleEnergyLimit::encode, PacketToggleEnergyLimit::decode, PacketToggleEnergyLimit::handle);
         CHANNEL.registerMessage(3, PacketChangeEnergyLimit.class, PacketChangeEnergyLimit::encode, PacketChangeEnergyLimit::decode, PacketChangeEnergyLimit::handle);
+        CHANNEL.registerMessage(4, PacketChangeItemFilter.class, PacketChangeItemFilter::encode, PacketChangeItemFilter::decode, PacketChangeItemFilter::handle);
+        CHANNEL.registerMessage(5, PacketChangeLiquidFilter.class, PacketChangeLiquidFilter::encode, PacketChangeLiquidFilter::decode, PacketChangeLiquidFilter::handle);
     }
 
     public void init(FMLCommonSetupEvent e){

--- a/src/main/java/com/supermartijn642/trashcans/compat/jei/GhostIngredientHandler.java
+++ b/src/main/java/com/supermartijn642/trashcans/compat/jei/GhostIngredientHandler.java
@@ -1,0 +1,102 @@
+package com.supermartijn642.trashcans.compat.jei;
+
+import com.supermartijn642.trashcans.TrashCanTile;
+import com.supermartijn642.trashcans.TrashCans;
+import com.supermartijn642.trashcans.compat.Compatibility;
+import com.supermartijn642.trashcans.filter.ItemFilter;
+import com.supermartijn642.trashcans.filter.LiquidTrashCanFilters;
+import com.supermartijn642.trashcans.packet.PacketChangeItemFilter;
+import com.supermartijn642.trashcans.packet.PacketChangeLiquidFilter;
+import com.supermartijn642.trashcans.screen.ItemTrashCanScreen;
+import com.supermartijn642.trashcans.screen.LiquidTrashCanScreen;
+import com.supermartijn642.trashcans.screen.TrashCanContainer;
+import com.supermartijn642.trashcans.screen.TrashCanScreen;
+import com.supermartijn642.trashcans.screen.UltimateTrashCanScreen;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
+import net.minecraft.client.renderer.Rectangle2d;
+import net.minecraft.inventory.container.Slot;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+
+public class GhostIngredientHandler implements IGhostIngredientHandler<TrashCanScreen> {
+
+    @Override
+    public <I> List<Target<I>> getTargets(TrashCanScreen screen, I ingredient, boolean doStart) {
+        // Sanity check. Doing this the proper way with generics seems like too much extra work.
+        if (!(screen.getContainer() instanceof TrashCanContainer)) {
+            return Collections.emptyList();
+        }
+        List<Target<I>> targets = new ArrayList<>();
+        for (Slot slot : screen.getContainer().inventorySlots) {
+            Rectangle2d bounds = new Rectangle2d(screen.getGuiLeft() + slot.xPos, screen.getGuiTop() + slot.yPos, 17, 17);
+
+            boolean isItemFilterSlot = (screen instanceof ItemTrashCanScreen && slot.slotNumber >= 1 && slot.slotNumber <= 9) || (screen instanceof UltimateTrashCanScreen && slot.slotNumber >= 3 && slot.slotNumber <= 11);
+            boolean isFluidFilterSlot = (screen instanceof LiquidTrashCanScreen && slot.slotNumber >= 1 && slot.slotNumber <= 9) || (screen instanceof UltimateTrashCanScreen && slot.slotNumber >= 12 && slot.slotNumber <= 20);
+
+            if (isItemFilterSlot && ingredient instanceof ItemStack) {
+                int filterSlotNum = screen instanceof ItemTrashCanScreen ? slot.slotNumber - 1 : slot.slotNumber - 3;
+                targets.add(new Target<I>() {
+                    @Override
+                    public Rectangle2d getArea() {
+                        return bounds;
+                    }
+
+                    @Override
+                    public void accept(I ingredient) {
+                        TrashCanTile tile = ((TrashCanContainer)screen.getContainer()).getTileOrClose();
+                        if (tile != null) {
+                            tile.itemFilter.set(filterSlotNum, (ItemStack)ingredient);
+                            TrashCans.CHANNEL.sendToServer(new PacketChangeItemFilter(tile.getPos(), filterSlotNum, (ItemStack)ingredient));
+                        }
+                    }
+                });
+            } else if (isFluidFilterSlot) {
+                ItemStack repitem = ItemStack.EMPTY;
+                if (ingredient instanceof ItemStack && isValidFluidItem((ItemStack)ingredient)) {
+                    repitem = (ItemStack)ingredient;
+                } else if (ingredient instanceof FluidStack) {
+                    repitem = new ItemStack(((FluidStack)ingredient).getFluid().getFilledBucket());
+                } else if (Compatibility.MEKANISM.isGasStack(ingredient)) {
+                    repitem = Compatibility.MEKANISM.getChemicalTankForGasStack(ingredient);
+                }
+                if (!repitem.isEmpty()) {
+                    ItemStack finalrepitem = repitem;
+                    int filterSlotNum = screen instanceof LiquidTrashCanScreen ? slot.slotNumber - 1 : slot.slotNumber - 12;
+                    targets.add(new Target<I>() {
+                        @Override
+                        public Rectangle2d getArea() {
+                            return bounds;
+                        }
+
+                        @Override
+                        public void accept(I ingredient) {
+                            ItemFilter filter = LiquidTrashCanFilters.createFilter(finalrepitem);
+                            if (filter != null) {
+                                TrashCanTile tile = ((TrashCanContainer)screen.getContainer()).getTileOrClose();
+                                if (tile != null) {
+                                    tile.liquidFilter.set(filterSlotNum, filter);
+                                    TrashCans.CHANNEL.sendToServer(new PacketChangeLiquidFilter(tile.getPos(), filterSlotNum, filter));
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        }
+        return targets;
+    }
+
+    @Override
+    public void onComplete() {} // NO-OP
+
+    private boolean isValidFluidItem(ItemStack stack) {
+        if (Compatibility.MEKANISM.doesItemHaveGasStored(stack)) return true;
+        IFluidHandlerItem fluidHandler = stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY).orElse(null);
+        return fluidHandler != null && fluidHandler.getTanks() == 1 && !fluidHandler.getFluidInTank(0).isEmpty();
+    }
+}

--- a/src/main/java/com/supermartijn642/trashcans/compat/jei/TrashCansJEIPlugin.java
+++ b/src/main/java/com/supermartijn642/trashcans/compat/jei/TrashCansJEIPlugin.java
@@ -1,0 +1,22 @@
+package com.supermartijn642.trashcans.compat.jei;
+
+import com.supermartijn642.trashcans.TrashCans;
+import com.supermartijn642.trashcans.screen.TrashCanScreen;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.registration.IGuiHandlerRegistration;
+import net.minecraft.util.ResourceLocation;
+
+@JeiPlugin
+public class TrashCansJEIPlugin implements IModPlugin {
+
+    @Override
+    public void registerGuiHandlers(IGuiHandlerRegistration registration) {
+        registration.addGhostIngredientHandler(TrashCanScreen.class, new GhostIngredientHandler());
+    }
+
+    @Override
+    public ResourceLocation getPluginUid() {
+        return new ResourceLocation(TrashCans.MODID, "jei_plugin");
+    }
+}

--- a/src/main/java/com/supermartijn642/trashcans/compat/mekanism/GasFilterManager.java
+++ b/src/main/java/com/supermartijn642/trashcans/compat/mekanism/GasFilterManager.java
@@ -1,11 +1,11 @@
 package com.supermartijn642.trashcans.compat.mekanism;
 
+import com.supermartijn642.trashcans.compat.Compatibility;
 import com.supermartijn642.trashcans.filter.IFilterManager;
 import com.supermartijn642.trashcans.filter.ItemFilter;
 import mekanism.api.chemical.gas.GasStack;
 import mekanism.api.chemical.gas.IGasHandler;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.registries.MekanismBlocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 
@@ -45,13 +45,7 @@ public class GasFilterManager implements IFilterManager {
 
         @Override
         public ItemStack getRepresentingItem(){
-            ItemStack stack = new ItemStack(MekanismBlocks.CREATIVE_CHEMICAL_TANK);
-            stack.getCapability(Capabilities.GAS_HANDLER_CAPABILITY).ifPresent(handler -> {
-                GasStack gas = this.stack.copy();
-                gas.setAmount(handler.getTankCapacity(0));
-                handler.setChemicalInTank(0, gas);
-            });
-            return stack;
+            return Compatibility.MEKANISM.getChemicalTankForGasStack(this.stack);
         }
 
         @Override

--- a/src/main/java/com/supermartijn642/trashcans/compat/mekanism/MekanismCompatOff.java
+++ b/src/main/java/com/supermartijn642/trashcans/compat/mekanism/MekanismCompatOff.java
@@ -32,4 +32,11 @@ public class MekanismCompatOff {
         return null;
     }
 
+    public boolean isGasStack(Object obj) {
+        return false;
+    }
+
+    public ItemStack getChemicalTankForGasStack(Object gasStack) {
+        return ItemStack.EMPTY;
+    }
 }

--- a/src/main/java/com/supermartijn642/trashcans/compat/mekanism/MekanismCompatOn.java
+++ b/src/main/java/com/supermartijn642/trashcans/compat/mekanism/MekanismCompatOn.java
@@ -7,6 +7,7 @@ import mekanism.api.chemical.gas.GasStack;
 import mekanism.api.chemical.gas.IGasHandler;
 import mekanism.api.chemical.gas.attribute.GasAttributes;
 import mekanism.common.capabilities.Capabilities;
+import mekanism.common.registries.MekanismBlocks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.capabilities.Capability;
 
@@ -101,5 +102,21 @@ public class MekanismCompatOn extends MekanismCompatOff {
                 return GasStack.EMPTY;
             }
         };
+    }
+
+    @Override
+    public boolean isGasStack(Object obj) {
+        return obj instanceof GasStack;
+    }
+
+    @Override
+    public ItemStack getChemicalTankForGasStack(Object gasStack) {
+        ItemStack stack = new ItemStack(MekanismBlocks.CREATIVE_CHEMICAL_TANK);
+        stack.getCapability(Capabilities.GAS_HANDLER_CAPABILITY).ifPresent(handler -> {
+            GasStack gas = ((GasStack)gasStack).copy();
+            gas.setAmount(handler.getTankCapacity(0));
+            handler.setChemicalInTank(0, gas);
+        });
+        return stack;
     }
 }

--- a/src/main/java/com/supermartijn642/trashcans/packet/PacketChangeItemFilter.java
+++ b/src/main/java/com/supermartijn642/trashcans/packet/PacketChangeItemFilter.java
@@ -1,0 +1,49 @@
+package com.supermartijn642.trashcans.packet;
+
+import com.supermartijn642.trashcans.TrashCanTile;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class PacketChangeItemFilter extends TrashCanPacket {
+    private int filterSlot;
+    private ItemStack stack;
+
+    public PacketChangeItemFilter(BlockPos pos, int filterSlot, ItemStack stack) {
+        super(pos);
+        this.filterSlot = filterSlot;
+        this.stack = stack;
+    }
+
+    public PacketChangeItemFilter(PacketBuffer buffer) {
+        super(buffer);
+    }
+
+    @Override
+    public void encode(PacketBuffer buffer) {
+        super.encode(buffer);
+        buffer.writeInt(filterSlot);
+        buffer.writeItemStack(stack);
+    }
+
+    @Override
+    protected void decodeBuffer(PacketBuffer buffer) {
+        super.decodeBuffer(buffer);
+        filterSlot = buffer.readInt();
+        stack = buffer.readItemStack();
+    }
+
+    public static PacketChangeItemFilter decode(PacketBuffer buffer) {
+        return new PacketChangeItemFilter(buffer);
+    }
+
+    @Override
+    protected void handle(PlayerEntity player, World world, TrashCanTile tile) {
+        if (tile.items) {
+            tile.itemFilter.set(filterSlot, stack);
+            tile.dataChanged();
+        }
+    }
+}

--- a/src/main/java/com/supermartijn642/trashcans/packet/PacketChangeLiquidFilter.java
+++ b/src/main/java/com/supermartijn642/trashcans/packet/PacketChangeLiquidFilter.java
@@ -1,0 +1,50 @@
+package com.supermartijn642.trashcans.packet;
+
+import com.supermartijn642.trashcans.TrashCanTile;
+import com.supermartijn642.trashcans.filter.ItemFilter;
+import com.supermartijn642.trashcans.filter.LiquidTrashCanFilters;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class PacketChangeLiquidFilter extends TrashCanPacket {
+    private int filterSlot;
+    private ItemFilter filter;
+
+    public PacketChangeLiquidFilter(BlockPos pos, int filterSlot, ItemFilter filter) {
+        super(pos);
+        this.filterSlot = filterSlot;
+        this.filter = filter;
+    }
+
+    public PacketChangeLiquidFilter(PacketBuffer buffer) {
+        super(buffer);
+    }
+
+    @Override
+    public void encode(PacketBuffer buffer) {
+        super.encode(buffer);
+        buffer.writeInt(filterSlot);
+        buffer.writeCompoundTag(LiquidTrashCanFilters.write(filter));
+    }
+
+    @Override
+    protected void decodeBuffer(PacketBuffer buffer) {
+        super.decodeBuffer(buffer);
+        filterSlot = buffer.readInt();
+        filter = LiquidTrashCanFilters.read(buffer.readCompoundTag());
+    }
+
+    public static PacketChangeLiquidFilter decode(PacketBuffer buffer) {
+        return new PacketChangeLiquidFilter(buffer);
+    }
+
+    @Override
+    protected void handle(PlayerEntity player, World world, TrashCanTile tile) {
+        if (tile.liquids) {
+            tile.liquidFilter.set(filterSlot, filter);
+            tile.dataChanged();
+        }
+    }
+}

--- a/src/main/java/com/supermartijn642/trashcans/screen/ArrowButton.java
+++ b/src/main/java/com/supermartijn642/trashcans/screen/ArrowButton.java
@@ -3,6 +3,7 @@ package com.supermartijn642.trashcans.screen;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.supermartijn642.trashcans.TrashCans;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.widget.button.AbstractButton;
 import net.minecraft.client.renderer.BufferBuilder;
@@ -17,7 +18,7 @@ import net.minecraft.util.text.StringTextComponent;
  */
 public class ArrowButton extends AbstractButton {
 
-    private final ResourceLocation BUTTONS = new ResourceLocation("trashcans", "textures/arrow_buttons.png");
+    private final ResourceLocation BUTTONS = new ResourceLocation(TrashCans.MODID, "textures/arrow_buttons.png");
 
     private final boolean left;
     private final Runnable onPress;

--- a/src/main/java/com/supermartijn642/trashcans/screen/CheckBox.java
+++ b/src/main/java/com/supermartijn642/trashcans/screen/CheckBox.java
@@ -3,6 +3,7 @@ package com.supermartijn642.trashcans.screen;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.supermartijn642.trashcans.TrashCans;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.widget.button.AbstractButton;
 import net.minecraft.client.renderer.BufferBuilder;
@@ -17,7 +18,7 @@ import net.minecraft.util.text.StringTextComponent;
  */
 public class CheckBox extends AbstractButton {
 
-    private final ResourceLocation BUTTONS = new ResourceLocation("trashcans", "textures/checkmarkbox.png");
+    private final ResourceLocation BUTTONS = new ResourceLocation(TrashCans.MODID, "textures/checkmarkbox.png");
 
     private final Runnable onPress;
     public boolean checked;

--- a/src/main/java/com/supermartijn642/trashcans/screen/TrashCanScreen.java
+++ b/src/main/java/com/supermartijn642/trashcans/screen/TrashCanScreen.java
@@ -3,6 +3,7 @@ package com.supermartijn642.trashcans.screen;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.supermartijn642.trashcans.TrashCanTile;
+import com.supermartijn642.trashcans.TrashCans;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.inventory.ContainerScreen;
 import net.minecraft.util.ResourceLocation;
@@ -64,7 +65,7 @@ public abstract class TrashCanScreen<T extends TrashCanContainer> extends Contai
     @Override
     protected void drawGuiContainerBackgroundLayer(MatrixStack matrixStack, float partialTicks, int mouseX, int mouseY){
         RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-        Minecraft.getInstance().getTextureManager().bindTexture(new ResourceLocation("trashcans", "textures/" + this.getBackground()));
+        Minecraft.getInstance().getTextureManager().bindTexture(new ResourceLocation(TrashCans.MODID, "textures/" + this.getBackground()));
         this.blit(matrixStack, this.guiLeft, this.guiTop, 0, 0, this.xSize, this.ySize);
 
         this.drawCenteredString(matrixStack, this.title, this.xSize / 2f, 6);

--- a/src/main/java/com/supermartijn642/trashcans/screen/UltimateTrashCanContainer.java
+++ b/src/main/java/com/supermartijn642/trashcans/screen/UltimateTrashCanContainer.java
@@ -8,8 +8,6 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.container.ClickType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
-import net.minecraftforge.energy.CapabilityEnergy;
-import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.SlotItemHandler;

--- a/src/main/java/com/supermartijn642/trashcans/screen/WhitelistButton.java
+++ b/src/main/java/com/supermartijn642/trashcans/screen/WhitelistButton.java
@@ -3,6 +3,7 @@ package com.supermartijn642.trashcans.screen;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.supermartijn642.trashcans.TrashCans;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.widget.button.AbstractButton;
 import net.minecraft.client.renderer.BufferBuilder;
@@ -17,7 +18,7 @@ import net.minecraft.util.text.StringTextComponent;
  */
 public class WhitelistButton extends AbstractButton {
 
-    private final ResourceLocation BUTTONS = new ResourceLocation("trashcans", "textures/blacklist_button.png");
+    private final ResourceLocation BUTTONS = new ResourceLocation(TrashCans.MODID, "textures/blacklist_button.png");
 
     public boolean white = true;
     private final Runnable onPress;


### PR DESCRIPTION
Added a JEI GhostIngredientHandler to allow for simpler filter setting. This allows users to drag items/fluids/gases from JEI into the filter slots, without needed them in their inventory.

While setting up the JEIPlugin, I noticed that DRY principles were not adhered to with respect to the mod id. As such, I just couldn't help myself and created one central constant to hold the modid :). On the plus-side, ObjectHolders will pull the modid prefix from the Mod annotation, so that code was extraneous.